### PR TITLE
Remove csv option

### DIFF
--- a/modules/cluster/src/main/java/org/apache/fluo/cluster/runner/AppRunner.java
+++ b/modules/cluster/src/main/java/org/apache/fluo/cluster/runner/AppRunner.java
@@ -209,14 +209,6 @@ public abstract class AppRunner {
             + "internal schema, making it easier to comprehend.")
     public boolean scanAccumuloTable = false;
 
-    public boolean exportAsCsv = false;
-    public String csvHeader;
-    public String csvDelimiter;
-    public String csvEscape;
-    public String csvQuote;
-    public String csvQuoteMode;
-    public boolean exportAsJson = false;
-
     public String getStartRow() {
       return startRow;
     }
@@ -242,8 +234,7 @@ public abstract class AppRunner {
 
     public ScanUtil.ScanOpts getScanOpts() {
       return new ScanUtil.ScanOpts(startRow, endRow, columns, exactRow, rowPrefix, help,
-          hexEncNonAscii, scanAccumuloTable, exportAsCsv, csvDelimiter, csvEscape, csvHeader,
-          csvQuote, csvQuoteMode, exportAsJson);
+          hexEncNonAscii, scanAccumuloTable, false);
     }
   }
 }

--- a/modules/command/pom.xml
+++ b/modules/command/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>accumulo-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
     </dependency>

--- a/modules/command/src/main/java/org/apache/fluo/command/FluoScan.java
+++ b/modules/command/src/main/java/org/apache/fluo/command/FluoScan.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.beust.jcommander.Parameter;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.fluo.api.config.FluoConfiguration;
 import org.apache.fluo.core.client.FluoAdminImpl;
 import org.apache.fluo.core.util.ScanUtil;
@@ -56,31 +55,6 @@ public class FluoScan {
             + "internal schema, making it easier to comprehend.")
     public boolean scanAccumuloTable = false;
 
-    @Parameter(names = "--csv", help = true,
-        description = "Export key/values stored in Accumulo as CSV file. Uses Fluo application "
-            + "properties to configure the CSV format.")
-    public boolean exportAsCsv = false;
-
-    @Parameter(names = "--csv-header", help = true, description = "Set header for \"true\".")
-    public String csvHeader;
-
-    @Parameter(names = "--csv-delimiter", help = true,
-        description = "Configure delimiter to a designeted character.")
-    public String csvDelimiter;
-
-    @Parameter(names = "--csv-escape", help = true,
-        description = "Configure escape to a designeted character.")
-    public String csvEscape;
-
-    @Parameter(names = "--csv-quote", help = true,
-        description = "Configure quote to a designeted character.")
-    public String csvQuote;
-
-    @Parameter(names = "--csv-quote-mode", help = true,
-        description = "Configure quote mode to a designeted mode. The possible "
-                + "modes are: ALL, ALL_NON_NULL, MINIMAL, NONE and NON_NUMERIC")
-    public String csvQuoteMode;
-
     @Parameter(names = "--json", help = true,
         description = "Export key/values stored in Accumulo as JSON file.")
     public boolean exportAsJson = false;
@@ -101,26 +75,6 @@ public class FluoScan {
       return rowPrefix;
     }
 
-    public String getCsvHeader() {
-      return csvHeader;
-    }
-
-    public String getCsvDelimiter() {
-      return csvDelimiter;
-    }
-
-    public String getCsvEscape() {
-      return csvEscape;
-    }
-
-    public String getCsvQuote() {
-      return csvQuote;
-    }
-
-    public String getCsvQuoteMode() {
-      return csvQuoteMode;
-    }
-
     public List<String> getColumns() {
       if (columns == null) {
         return Collections.emptyList();
@@ -130,25 +84,17 @@ public class FluoScan {
 
     /**
      * Check if the parameters informed can be used together.
-     * @since 1.2
      */
     private void checkScanOptions() {
-      if (this.exportAsCsv && this.exportAsJson) {
+      if (this.scanAccumuloTable && this.exportAsJson) {
         throw new IllegalArgumentException(
-            "Both \"--csv\" and \"--json\" can not be set together.");
-      }
-
-      if (!this.exportAsCsv && (StringUtils.isNotEmpty(this.csvDelimiter)
-          | StringUtils.isNotEmpty(this.csvEscape) | StringUtils.isNotEmpty(this.csvHeader)
-          | StringUtils.isNotEmpty(this.csvQuote) | StringUtils.isNotEmpty(this.csvQuoteMode))) {
-        throw new IllegalArgumentException("No \"--csv\" detected");
+            "Both \"--raw\" and \"--json\" can not be set together.");
       }
     }
 
     public ScanUtil.ScanOpts getScanOpts() {
       return new ScanUtil.ScanOpts(startRow, endRow, columns, exactRow, rowPrefix, help,
-          hexEncNonAscii, scanAccumuloTable, exportAsCsv, csvDelimiter, csvEscape, csvHeader,
-          csvQuote, csvQuoteMode, exportAsJson);
+          hexEncNonAscii, scanAccumuloTable, exportAsJson);
     }
 
     public static ScanOptions parse(String[] args) {

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -50,14 +50,6 @@
       <artifactId>accumulo-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-csv</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
     </dependency>

--- a/modules/distribution/src/main/lib/fetch.sh
+++ b/modules/distribution/src/main/lib/fetch.sh
@@ -62,8 +62,6 @@ extra)
   download commons-collections:commons-collections:jar:3.2.1
   download commons-configuration:commons-configuration:jar:1.10
   download commons-io:commons-io:jar:2.4
-  download org.apache.commons:commons-csv:jar:1.5
-  download org.apache.commons:commons-lang3:jar:3.7
   download io.dropwizard.metrics:metrics-core:jar:3.1.1
   download io.dropwizard.metrics:metrics-graphite:jar:3.1.1
   download javax.inject:javax.inject:jar:1

--- a/pom.xml
+++ b/pom.xml
@@ -140,16 +140,6 @@
         <version>${accumulo.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-csv</artifactId>
-        <version>1.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.7</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-client</artifactId>
         <version>${curator.version}</version>


### PR DESCRIPTION
@alanblueshift I removed the csv code because I realized that we could use [jq](https://stedolan.github.io/jq/) to convert json to csv on the command line.  What do you think of these changes?

```
$ fluo scan -a test1
row1 f1 q1 	v1
row1 f1 q2 	v2
row2 f1 q1 	v3
$ fluo scan -a test1 --json
{"row":"row1","family":"f1","qualifier":"q1","visibility":"","value":"v1"}
{"row":"row1","family":"f1","qualifier":"q2","visibility":"","value":"v2"}
{"row":"row2","family":"f1","qualifier":"q1","visibility":"","value":"v3"}
$ fluo scan -a test1 --json | jq -r '[.row, .family, .qualifier, .value]|@csv'
"row1","f1","q1","v1"
"row1","f1","q2","v2"
"row2","f1","q1","v3"
```